### PR TITLE
Add gradient angle slider inside the gradient color picker window

### DIFF
--- a/src/components/colorTool.jsx
+++ b/src/components/colorTool.jsx
@@ -21,6 +21,8 @@ function ColorTool({
   onGradientToggle,
   gradient,
   gradColors,
+  gradAngle,
+  setGradAngle,
 }) {
   const [colorTool, setColorTool] = useState(
     gradient ? colorToolMode.GRADIENT : colorToolMode.COLOR,
@@ -149,6 +151,8 @@ function ColorTool({
               onGradColorsChange={onGradColorsChange}
               gradColors={gradColors}
               isDark={isDark}
+              gradAngle={gradAngle}
+              setGradAngle={setGradAngle}
             />
           )}
         </div>

--- a/src/components/customBar.jsx
+++ b/src/components/customBar.jsx
@@ -17,6 +17,8 @@ function CustomBar({
   gradient,
   gradColors,
   handleWaveTransform,
+  setGradAngle,
+  gradAngle,
 }) {
   const [segmentCount, setSegmentCount] = useState(5)
   const [layerCount, setLayoutCount] = useState(3)
@@ -153,6 +155,8 @@ function CustomBar({
         onGradientToggle={onGradientToggle}
         gradient={gradient}
         gradColors={gradColors}
+        setGradAngle={setGradAngle}
+        gradAngle={gradAngle}
       />
 
       <div className="flex flex-col w-full mt-2">

--- a/src/components/gradientPicker.jsx
+++ b/src/components/gradientPicker.jsx
@@ -105,18 +105,10 @@ function GradientPicker({
 }
 
 const DegreeInput = ({ gradAngle, setGradAngle }) => {
-<<<<<<< HEAD
   return (
     <div className="text-center p-3">
       <label
         htmlFor="gradient-angle"
-=======
-  console.log()
-  return (
-    <div className="text-center p-3">
-      <label
-        htmlFor="gradient-degrees"
->>>>>>> 221553c7f551e5ce642e538deb69acbac1416867
         className="text-sm tracking-widest text-center uppercase"
       >
         Gradient angle
@@ -126,13 +118,8 @@ const DegreeInput = ({ gradAngle, setGradAngle }) => {
         value={gradAngle}
         onChange={(e) => setGradAngle(e.target.value)}
         type="range"
-<<<<<<< HEAD
         id="gradient-angle"
         name="gradient-angle"
-=======
-        id="gradient-degrees"
-        name="gradient-degrees"
->>>>>>> 221553c7f551e5ce642e538deb69acbac1416867
         min="0"
         max="360"
         step="1"

--- a/src/components/gradientPicker.jsx
+++ b/src/components/gradientPicker.jsx
@@ -10,7 +10,13 @@ import { TwitterPicker } from 'react-color'
 import './../styles/sideBar.css'
 import { useDarkModeState } from './../hooks/useDarkMode'
 
-function GradientPicker({ gradColors, onGradColorsChange, isDark }) {
+function GradientPicker({
+  gradColors,
+  onGradColorsChange,
+  isDark,
+  gradAngle,
+  setGradAngle,
+}) {
   const [colorOne, setColorOne] = useState(gradColors.colorOne)
   const [colorTwo, setColorTwo] = useState(gradColors.colorTwo)
   const [currentColor, setCurrentColor] = useState(gradColorNum.ONE)
@@ -93,6 +99,32 @@ function GradientPicker({ gradColors, onGradColorsChange, isDark }) {
         {gradientBox}
       </div>
       {colorPicker}
+      <DegreeInput gradAngle={gradAngle} setGradAngle={setGradAngle} />
+    </div>
+  )
+}
+
+const DegreeInput = ({ gradAngle, setGradAngle }) => {
+  return (
+    <div className="text-center p-3">
+      <label
+        htmlFor="gradient-angle"
+        className="text-sm tracking-widest text-center uppercase"
+      >
+        Gradient angle
+      </label>
+      <input
+        className="w-full h-3 overflow-hidden bg-gray-400 rounded-lg appearance-none"
+        value={gradAngle}
+        onChange={(e) => setGradAngle(e.target.value)}
+        type="range"
+        id="gradient-angle"
+        name="gradient-angle"
+        min="0"
+        max="360"
+        step="1"
+      />
+      <span className="text-sm uppercase">{gradAngle}°</span>
     </div>
   )
 }

--- a/src/components/home.jsx
+++ b/src/components/home.jsx
@@ -17,6 +17,7 @@ function Home({ isDark, toggleDarkMode }) {
     colorOne: '#002bdc',
     colorTwo: '#32ded4',
   })
+  const [gradAngle, setGradAngle] = useState(0)
 
   const svgElement = useRef(null)
   const bgSvgElement = useRef(null)
@@ -88,9 +89,16 @@ function Home({ isDark, toggleDarkMode }) {
         }
 
         if (gradient) {
+          const anglePI = gradAngle * (Math.PI / 180)
           pathProps.push(
             <defs>
-              <linearGradient id={`gradient`}>
+              <linearGradient
+                id={`gradient`}
+                x1={Math.round(50 + Math.sin(anglePI) * 50) + '%'}
+                y1={Math.round(50 + Math.cos(anglePI) * 50) + '%'}
+                x2={Math.round(50 + Math.sin(anglePI + Math.PI) * 50) + '%'}
+                y2={Math.round(50 + Math.cos(anglePI + Math.PI) * 50) + '%'}
+              >
                 <stop
                   offset="5%"
                   stop-color={`${gradColors.colorOne}${opac[index]}`}
@@ -132,10 +140,17 @@ function Home({ isDark, toggleDarkMode }) {
       className="transition duration-300 ease-in-out delay-150"
     >
       {path.map((p, index) => {
+        const anglePI = gradAngle * (Math.PI / 180)
         return gradient ? (
           [
             <defs>
-              <linearGradient id={`gradient`}>
+              <linearGradient
+                id={`gradient`}
+                x1={Math.round(50 + Math.sin(anglePI) * 50) + '%'}
+                y1={Math.round(50 + Math.cos(anglePI) * 50) + '%'}
+                x2={Math.round(50 + Math.sin(anglePI + Math.PI) * 50) + '%'}
+                y2={Math.round(50 + Math.cos(anglePI + Math.PI) * 50) + '%'}
+              >
                 <stop
                   offset="5%"
                   stop-color={`${
@@ -208,7 +223,7 @@ function Home({ isDark, toggleDarkMode }) {
           background: isDark
             ? '#131e2b66'
             : gradient
-            ? `linear-gradient(90deg, ${gradColors.colorOne}33 0%, ${gradColors.colorTwo}33 100%)`
+            ? `linear-gradient(${gradAngle}deg, ${gradColors.colorOne}33 0%, ${gradColors.colorTwo}33 100%)`
             : `${bgColor}33`,
         }}
       >
@@ -235,6 +250,8 @@ function Home({ isDark, toggleDarkMode }) {
             isDark={isDark}
             gradient={gradient}
             gradColors={gradColors}
+            gradAngle={gradAngle}
+            setGradAngle={setGradAngle}
           />
         </div>
       </div>

--- a/src/components/home.jsx
+++ b/src/components/home.jsx
@@ -17,7 +17,7 @@ function Home({ isDark, toggleDarkMode }) {
     colorOne: '#002bdc',
     colorTwo: '#32ded4',
   })
-  const [gradAngle, setGradAngle] = useState(0)
+  const [gradAngle, setGradAngle] = useState(270)
 
   const svgElement = useRef(null)
   const bgSvgElement = useRef(null)


### PR DESCRIPTION
Added a slider to choose an angle for the  gradient color (issue #37 )

Tried to implement it using `gradientTransform="rotate(degree)"` but noticed that it uses the SVG 0,0 as anchor so the gradient didn't work in all cases. Implemented by calculating the coorditates used in the fill instead.