### PR TITLE
use stopOpacity instead of #RRGGBBAA

### DIFF
--- a/src/components/home.jsx
+++ b/src/components/home.jsx
@@ -101,11 +101,13 @@ function Home({ isDark, toggleDarkMode }) {
               >
                 <stop
                   offset="5%"
-                  stopColor={`${gradColors.colorOne}${opac[index]}`}
+                  stopColor={`${gradColors.colorOne}`}
+                  stopOpacity={opac[index]}
                 />
                 <stop
                   offset="95%"
-                  stopColor={`${gradColors.colorTwo}${opac[index]}`}
+                  stopColor={`${gradColors.colorTwo}`}
+                  stopOpacity={opac[index]}
                 />
               </linearGradient>
             </defs>,
@@ -153,15 +155,13 @@ function Home({ isDark, toggleDarkMode }) {
               >
                 <stop
                   offset="5%"
-                  stopColor={`${
-                    invert ? gradColors.colorTwo : gradColors.colorOne
-                  }${opac[index]}`}
+                  stopColor={invert ? gradColors.colorTwo : gradColors.colorOne}
+                  stopOpacity={opac[index]}
                 />
                 <stop
                   offset="95%"
-                  stopColor={`${
-                    invert ? gradColors.colorOne : gradColors.colorTwo
-                  }${opac[index]}`}
+                  stopColor={invert ? gradColors.colorOne : gradColors.colorTwo}
+                  stopOpacity={opac[index]}
                 />
               </linearGradient>
             </defs>,

--- a/src/components/home.jsx
+++ b/src/components/home.jsx
@@ -4,7 +4,7 @@ import Canvas from './canvas'
 import CustomBar from './customBar'
 import Navbar from './nav'
 import { waveInit } from '../core'
-import { OPACITY_ARR, MAX_WAVES } from './../constants'
+import { OPACITY_ARR, MAX_WAVES, GRADIENT_OPACITY_ARR } from './../constants'
 import SVGCode from './svgCode'
 import saveSvgAsPng from 'save-svg-as-png'
 
@@ -42,7 +42,9 @@ function Home({ isDark, toggleDarkMode }) {
 
   const { height, xmlns, path, animatedPath } = waveSvg.svg
   const num_waves = path.length
-  const opac = OPACITY_ARR.slice(MAX_WAVES - num_waves)
+  const opac = gradient
+    ? GRADIENT_OPACITY_ARR.slice(MAX_WAVES - num_waves)
+    : OPACITY_ARR.slice(MAX_WAVES - num_waves)
   const cw = waveSvg.svg.width / 2
   const ch = waveSvg.svg.height / 2
   const transformData = `rotate(-180 ${cw} ${ch})`

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,6 +1,7 @@
 export const OPACITY = 33
 
-export const OPACITY_ARR = ['0.267', '0.4', '0.534', '1']
+export const OPACITY_ARR = ['44', '66', '88', 'ff']
+export const GRADIENT_OPACITY_ARR = ['0.267', '0.4', '0.534', '1'] // Transformed OPACITY_ARR into values from 0 to 1
 
 export const MAX_WAVES = 4
 

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,6 +1,6 @@
 export const OPACITY = 33
 
-export const OPACITY_ARR = ['44', '66', '88', 'ff']
+export const OPACITY_ARR = ['0.267', '0.4', '0.534', '1']
 
 export const MAX_WAVES = 4
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3346,6 +3346,11 @@ get-value@^2.0.3, get-value@^2.0.6:
   resolved "https://registry.yarnpkg.com/get-value/-/get-value-2.0.6.tgz#dc15ca1c672387ca76bd37ac0a395ba2042a2c28"
   integrity sha1-3BXKHGcjh8p2vTesCjlbogQqLCg=
 
+github-buttons@^2.8.0:
+  version "2.19.1"
+  resolved "https://registry.yarnpkg.com/github-buttons/-/github-buttons-2.19.1.tgz#9703755a4da1c5b229d3f1d875c2f787efa59bd5"
+  integrity sha512-us6ZC0bFYLfBq2CkZJJRpdPP5JlB6+kWFTdw8iK3E7yoMKdoLhDkqQHelJ+39UVR2zQbfXN5gNt3cVYp4fAuXA==
+
 glob-parent@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-3.1.0.tgz#9e6af6299d8d3bd2bd40430832bd113df906c5ae"
@@ -5787,6 +5792,13 @@ react-color@^2.18.1:
     prop-types "^15.5.10"
     reactcss "^1.2.0"
     tinycolor2 "^1.4.1"
+
+react-github-btn@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/react-github-btn/-/react-github-btn-1.2.1.tgz#ece93f609a4bad5e7eb9f47ae49bfaba69466dce"
+  integrity sha512-/gXD01mHAOhW0xYuNJFDn08OGjaMXOjcg6GCKVPdHvQcWzswH4aT85DLDAAJ6Zhw/71veSIH4Kx1BTBfy69SsA==
+  dependencies:
+    github-buttons "^2.8.0"
 
 react-is@^16.8.1:
   version "16.13.1"


### PR DESCRIPTION
Closes #26 

Mapped opacity array from 0 to 1
```diff
- export const OPACITY_ARR = ['44', '66', '88', 'ff']
+ export const OPACITY_ARR = ['0.267', '0.4', '0.534', '1']
```

Tested the output with browser stack.

## Earlier
![image](https://user-images.githubusercontent.com/4337699/136438286-f478d23e-0a65-401b-ad16-9be2404d4ac4.png)

## Now
![image](https://user-images.githubusercontent.com/4337699/136438301-f054c2b8-ac8a-4aaa-9e4b-261424a22541.png)
